### PR TITLE
update wkhtmltopdf to version 0.12.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 wkhtmltopdf-binary
 ==================
 
-wkhtmltopdf-binary provides the [wkhtmltopdf](http://wkhtmltopdf.org) binary
+wkhtmltopdf-binary provides the [wkhtmltopdf](https://wkhtmltopdf.org) binary
 packaged in a Jar as dependency for Java applications.
 
 Note: The current version only supports Linux and OS X (amd64) architecture, but this
@@ -15,7 +15,7 @@ The Jar file can be built with [Gradle].
 
 The resulting Jar files can be found in ```build/libs/```.
 
-[Gradle]: http://gradle.org
+[Gradle]: https://gradle.org
 
 In your Java code, you can run the wkhtmltopdf binary.
 
@@ -41,7 +41,7 @@ Build has been tested on Linux. Dependencies for building:
 
 * bash
 * tar
-* xar
+* 7z
 * cpio
 * gunzip
 
@@ -54,7 +54,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this work except in compliance with the License.
 You may obtain a copy of the License in the LICENSE file, or at:
 
-  [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+  [https://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,11 @@ sourceSets {
 }
 
 group = "ch.tocco.wkhtmltopdf.binary"
-version = "0.12.3"
+version = "0.12.4"
 
 import de.undercouch.gradle.tasks.download.Download
 
-def downloadOrigin = "http://download.gna.org/wkhtmltopdf/0.12/"
+def downloadOrigin = "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/"
 
 task downloadLinuxFile(type: Download) {
     src downloadOrigin + version + "/wkhtmltox-" + version + "_linux-generic-amd64.tar.xz"
@@ -61,12 +61,12 @@ task extractLinuxFile(dependsOn: downloadLinuxFile, type: Exec) {
 task extractPayload(dependsOn: downloadOsxFile, type: Exec) {
     def osxBuildDir = new File(buildDir.toString() + "/osx/")
     osxBuildDir.mkdirs()
-    executable "xar"
-    args "-xf", downloadOsxFile.dest, "-C", osxBuildDir.toString(), "Payload"
+    executable "7z"
+    args "x", downloadOsxFile.dest, "-w", "-o" + osxBuildDir.toString(), "-y"
 }
 
 task extractAppTar(dependsOn: extractPayload, type: Exec) {
-    commandLine "bash", "-c", "gunzip -c ${buildDir.toString()}/osx/Payload | cpio -i --directory=${buildDir.toString()}/osx/"
+    commandLine "bash", "-c", "( cd ${buildDir.toString()}/osx/; cpio -i; ) <${buildDir.toString()}/osx/Payload~"
 }
 
 task extractBinary(dependsOn: extractAppTar, type: Exec) {


### PR DESCRIPTION
• update from 0.12.3 to 0.12.4
• use HTTPS
• replace xar with 7z (xar isn't available on many Linux distros)
• don't use --directory for cpio, it's not available in some cpio
  implementations